### PR TITLE
ファイル書き込みのファイルを一時ファイルに変更

### DIFF
--- a/opthub_client/context/match_selection.py
+++ b/opthub_client/context/match_selection.py
@@ -1,9 +1,8 @@
 """This module contains the class related to match selection context."""
 
-import sys
+import shelve
+import tempfile
 from pathlib import Path
-
-import click
 
 from opthub_client.models.competition import Competition
 from opthub_client.models.match import Match
@@ -12,59 +11,30 @@ from opthub_client.models.match import Match
 class MatchSelectionContext:
     """The selection context of match."""
 
-    match_id: str | None
-    competition_id: str | None
-    match_alias: str | None
-    competition_alias: str | None
-    file_path: str
-
     def __init__(self) -> None:
-        """Initialize the match selection context."""
-        self.file_path = ".match_selection"
-        self.competition_id = None
-        self.match_id = None
+        """Initialize the match selection context with a persistent temporary file."""
+        temp_dir = tempfile.gettempdir()
+        temp_file_name = "match_selection"
+        self.file_path = Path(temp_dir) / temp_file_name
+        self.db = shelve.open(str(self.file_path))
         self.load()
 
     def load(self) -> None:
-        """Load the match selection from file."""
-        if Path.exists(Path(self.file_path)) is not True:
-            # file is not found
-            self.competition_id = None
-            self.match_id = None
-            self.competition_alias = None
-            self.match_alias = None
-            return
-        try:
-            with Path.open(Path(self.file_path)) as file:
-                content = file.read()
-                parts = content.split(",")
-                self.competition_id = parts[0].split(":")[0]
-                self.competition_alias = parts[0].split(":")[1]
-                self.match_id = parts[1].split(":")[0]
-                self.match_alias = parts[1].split(":")[1]
-        except OSError as e:
-            click.echo(
-                f"An error occurred while reading the file: {e}. Please select competition and match again",
-                file=sys.stderr,
-            )
-            self.competition_id = None
-            self.competition_alias = None
-            self.match_id = None
-            self.match_alias = None
-            return
+        """Load the match selection from the shelve file."""
+        self.competition_id = self.db.get("competition_id")
+        self.match_id = self.db.get("match_id")
+        self.match_alias = self.db.get("match_alias")
+        self.competition_alias = self.db.get("competition_alias")
 
     def update(self, competition: Competition, match: Match) -> None:
-        """Update the match selection.
+        """Update the match selection in the shelve file.
 
         Args:
             competition (Competition): Competition instance
             match (Match): Match instance
         """
-        self.competition_id = competition["id"]
-        self.competition_alias = competition["alias"]
-        self.match_id = match["id"]
-        self.match_alias = match["alias"]
-        with Path.open(Path(self.file_path), "w") as file:
-            file.write(
-                self.competition_id + ": " + self.competition_alias + "," + self.match_id + ": " + self.match_alias,
-            )
+        self.db["competition_id"] = competition["id"]
+        self.db["match_id"] = match["id"]
+        self.db["match_alias"] = match["alias"]
+        self.db["competition_alias"] = competition["alias"]
+        self.db.sync()


### PR DESCRIPTION
# 目的・解決すること
ファイル書き込みをtmpfileなどのライブラリを使ってできるように変更

close #24 

# 変更内容

- ファイル書き込みをtmpfileライブラリを用いるように変更
- ファイル書き込みの際に、shleveを用いるよう変更

# テスト項目

- ファイル書き込みを行う部分の確認
- selectによって選択したマッチとコンペをsubmit時にも選択できていることを確認

# 備考

このshelveを使う際に、色々とライブラリ周りのバグが出て色々やった結果できたが、自分の環境だけ動くようになっているのか、他の人の環境でも動くのかがわからない