### PR TITLE
fix: change query to mutation in create_api_key

### DIFF
--- a/opthub_client/models/api_key.py
+++ b/opthub_client/models/api_key.py
@@ -18,8 +18,8 @@ class ApiKey(TypedDict):
 
 def create_api_key(force: bool) -> ApiKey:
     """Create and get API key from the server."""
-    query = gql("""
-        query createAPIKey(
+    mutation = gql("""
+        mutation createAPIKey(
         $force: Boolean
         ) {
             createAPIKey(
@@ -31,7 +31,7 @@ def create_api_key(force: bool) -> ApiKey:
         }
     """)
     try:
-        result = execute_graphql(query, variables={"force": force})
+        result = execute_graphql(mutation, variables={"force": force})
     except GraphQLError as e:
         raise QueryError(resource="api_key", detail=str(e.message)) from e
     data = result.get("createAPIKey")


### PR DESCRIPTION
# 目的・解決すること
create_api_key関数のqueryをmutaitionに変更
close #129 
# 変更内容
- create_api_keyのqueryをmutationに変更
# テスト項目
- opt create api_keyが正常に動くことを確認
# 備考
