### PR TITLE
feat: Require the -e option for the download command

### DIFF
--- a/opthub_client/controllers/download.py
+++ b/opthub_client/controllers/download.py
@@ -32,7 +32,7 @@ SIZE_FETCH_TRIALS = 50
     "-e",
     "--end",
     type=click.IntRange(min=1),
-    default=SIZE_FETCH_TRIALS,
+    required=True,
     help="End trial number",
 )
 @click.option("-desc", "--descending", is_flag=True, help="Show trials in descending order")


### PR DESCRIPTION
# 目的・解決すること
- downloadコマンドの−eオプションを必須に変更
close #91 
# 変更内容
- opt download -eを必須に変更
# テスト項目
- opt download -eが動くことを確認
- opt download だけではエラーが出ることを確認
# 備考